### PR TITLE
Сделать историю посещений неограниченной по размеру и без повторов

### DIFF
--- a/src/manager/HistoryManager.java
+++ b/src/manager/HistoryManager.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 public interface HistoryManager {
     void add(Task task);
+
     void remove(int id);
+
     List<Task> getHistory();
 }

--- a/src/manager/HistoryManager.java
+++ b/src/manager/HistoryManager.java
@@ -2,10 +2,10 @@ package manager;
 
 import classes.tasks.Task;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public interface HistoryManager {
     void add(Task task);
-
-    ArrayList<Task> getHistory();
+    void remove(int id);
+    List<Task> getHistory();
 }

--- a/src/manager/InMemoryHistoryManager.java
+++ b/src/manager/InMemoryHistoryManager.java
@@ -1,6 +1,5 @@
 package manager;
 
-import classes.tasks.Epic;
 import classes.tasks.Task;
 
 import java.util.*;

--- a/src/manager/InMemoryHistoryManager.java
+++ b/src/manager/InMemoryHistoryManager.java
@@ -1,26 +1,126 @@
 package manager;
 
+import classes.tasks.Epic;
 import classes.tasks.Task;
 
-import java.util.ArrayList;
+import java.util.*;
 
 public class InMemoryHistoryManager implements HistoryManager {
-    private final ArrayList<Task> historyOfTasks;
-    private static final int SIZE=10;
+
+    private Node head;
+    private Node tail;
+    private int size;
+    private final Map<Integer, Node> historyManager;
+
     public InMemoryHistoryManager() {
-        historyOfTasks = new ArrayList<>();
+        historyManager = new HashMap<>();
     }
+
+    private void linkLast(Task element) {
+        Node oldTail = tail;
+        Node newNode = new Node(oldTail, element, null);
+        tail = newNode;
+        if (oldTail == null) {
+            head = tail;
+        } else {
+            oldTail.next = newNode;
+        }
+        size++;
+        historyManager.put(element.getId(), newNode);
+    }
+
+    private List<Task> getTasks() {
+        List<Task> listOfTasks = new ArrayList<>();
+        Node currentHead = head;
+        int size = 0;
+        if (head.data == tail.data) {
+            listOfTasks.add(tail.data);
+            return listOfTasks;
+        }
+        while (size < this.size) {
+            listOfTasks.add(currentHead.data);
+            currentHead = currentHead.next;
+            size++;
+        }
+        return listOfTasks;
+    }
+
+    private void removeNode(Node node) {
+        if (node.equals(head) && size == 2) {
+            tail.prev = null;
+            head = tail;
+        } else if (node.equals(tail) && size == 2) {
+            head.next = null;
+            tail = head;
+        } else if (node.equals(tail)) {
+            Node oldTail = tail;
+            Node newNode = new Node(oldTail.prev.prev, oldTail.prev.data, null);
+            tail = newNode;
+            oldTail.prev.prev.next = newNode;
+        } else {
+            node.data = node.next.data;
+            if (node.data == tail.data) {
+                tail = node;
+                tail.next = null;
+                tail.prev.next = tail;
+            } else {
+                node.next = node.next.next;
+                node.next.prev = node;
+            }
+        }
+
+        size--;
+        historyManager.put(node.data.getId(), node);
+    }
+
 
     @Override
     public void add(Task task) {
-        if (historyOfTasks.size() == SIZE) {
-            historyOfTasks.removeFirst();
+        Node nodeInHistory = historyManager.get(task.getId());
+        if (historyManager.containsKey(task.getId()) && !nodeInHistory.equals(tail) && size != 1) {
+            removeNode(nodeInHistory);
+            linkLast(task);
+        } else if (!historyManager.containsKey(task.getId())) {
+            linkLast(task);
         }
-        historyOfTasks.add(task);
     }
 
     @Override
-    public ArrayList<Task> getHistory() {
-        return historyOfTasks;
+    public void remove(int id) {
+        if (historyManager.containsKey(id)) {
+            removeNode(historyManager.get(id));
+            historyManager.remove(id);
+        }
+    }
+
+    @Override
+    public List<Task> getHistory() {
+        return getTasks();
+    }
+
+    class Node {
+        public Task data;
+        public Node next;
+        public Node prev;
+
+        public Node(Node prev, Task data, Node next) {
+            this.data = data;
+            this.next = next;
+            this.prev = prev;
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) return true;
+            if (object == null || getClass() != object.getClass()) return false;
+            Node node = (Node) object;
+            return Objects.equals(data, node.data) && Objects.equals(next, node.next) && Objects.equals(prev, node.prev);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(data, next, prev);
+        }
     }
 }
+

--- a/src/manager/InMemoryHistoryManager.java
+++ b/src/manager/InMemoryHistoryManager.java
@@ -8,7 +8,6 @@ public class InMemoryHistoryManager implements HistoryManager {
 
     private Node head;
     private Node tail;
-    private int size;
     private final Map<Integer, Node> historyManager;
 
     public InMemoryHistoryManager() {
@@ -24,64 +23,52 @@ public class InMemoryHistoryManager implements HistoryManager {
         } else {
             oldTail.next = newNode;
         }
-        size++;
         historyManager.put(element.getId(), newNode);
     }
 
     private List<Task> getTasks() {
         List<Task> listOfTasks = new ArrayList<>();
         Node currentHead = head;
-        int size = 0;
-        if (head.data == tail.data) {
-            listOfTasks.add(tail.data);
-            return listOfTasks;
-        }
-        while (size < this.size) {
-            listOfTasks.add(currentHead.data);
+        listOfTasks.add(head.data);
+        while (currentHead.data != null && currentHead.data != tail.data) {
             currentHead = currentHead.next;
-            size++;
+            listOfTasks.add(currentHead.data);
         }
         return listOfTasks;
     }
 
     private void removeNode(Node node) {
-        if (node.equals(head) && size == 2) {
-            tail.prev = null;
-            head = tail;
-        } else if (node.equals(tail) && size == 2) {
-            head.next = null;
-            tail = head;
-        } else if (node.equals(tail)) {
-            Node oldTail = tail;
-            Node newNode = new Node(oldTail.prev.prev, oldTail.prev.data, null);
-            tail = newNode;
-            oldTail.prev.prev.next = newNode;
+        if (node.data == head.data && node.data == tail.data) {
+            head = null;
+            tail = null;
         } else {
-            node.data = node.next.data;
-            if (node.data == tail.data) {
-                tail = node;
-                tail.next = null;
-                tail.prev.next = tail;
+            if (node.equals(head)) {
+                node.next.prev = null;
+                head = node.next;
+                historyManager.put(head.data.getId(), head);
             } else {
-                node.next = node.next.next;
-                node.next.prev = node;
+                if (node.equals(tail)) {
+                    node.prev.next = null;
+                    tail = node.prev;
+                    historyManager.put(tail.data.getId(), tail);
+                } else {
+                    node.prev.next = node.next;
+                    node.next.prev = node.prev;
+                    historyManager.put(node.prev.data.getId(), node.prev);
+                    historyManager.put(node.next.data.getId(), node.next);
+                }
             }
         }
-
-        size--;
-        historyManager.put(node.data.getId(), node);
     }
 
 
     @Override
     public void add(Task task) {
         Node nodeInHistory = historyManager.get(task.getId());
-        if (historyManager.containsKey(task.getId()) && !nodeInHistory.equals(tail) && size != 1) {
+        if (historyManager.containsKey(task.getId())) {
             removeNode(nodeInHistory);
-            linkLast(task);
-        } else if (!historyManager.containsKey(task.getId())) {
-            linkLast(task);
         }
+        linkLast(task);
     }
 
     @Override
@@ -97,12 +84,12 @@ public class InMemoryHistoryManager implements HistoryManager {
         return getTasks();
     }
 
-    class Node {
-        public Task data;
-        public Node next;
-        public Node prev;
+    private static class Node {
+        private final Task data;
+        private Node next;
+        private Node prev;
 
-        public Node(Node prev, Task data, Node next) {
+        private Node(Node prev, Task data, Node next) {
             this.data = data;
             this.next = next;
             this.prev = prev;

--- a/src/manager/InMemoryTaskManager.java
+++ b/src/manager/InMemoryTaskManager.java
@@ -142,7 +142,7 @@ public class InMemoryTaskManager implements TaskManager {
         HashMap<Integer, Subtask> subtasksListOfEpic = epic.getSubtasksList();
         subtasksListOfEpic.remove(id);
         epic.updateStatus();
-        deleteSubtaskByIdFromHistory(id, epic);
+        deleteSubtaskByIdFromHistory(id);
         subtasksList.remove(id);
     }
 
@@ -153,25 +153,44 @@ public class InMemoryTaskManager implements TaskManager {
     }
 
     @Override
-    public ArrayList<Task> getHistory() {
+    public List<Task> getHistory() {
         return historyManager.getHistory();
     }
 
     private void deleteAllTasksFromHistory() {
-        historyManager.getHistory().removeIf(tasksList::containsValue);
+        List<Task> tasksInHistory = historyManager.getHistory();
+        for (Task task : tasksList.values()) {
+            if (tasksInHistory.contains(task)) {
+                historyManager.remove(task.getId());
+            }
+        }
     }
 
     private void deleteAllEpicsFromHistory() {
-        historyManager.getHistory().removeIf(epicsList::containsValue);
-        historyManager.getHistory().removeIf(subtasksList::containsValue);
+        List<Task> epicsInHistory = historyManager.getHistory();
+        for (Task task : epicsList.values()) {
+            if (epicsInHistory.contains(task)) {
+                historyManager.remove(task.getId());
+            }
+        }
+        for (Task task : subtasksList.values()) {
+            if (epicsInHistory.contains(task)) {
+                historyManager.remove(task.getId());
+            }
+        }
     }
 
     private void deleteAllSubtasksFromHistory() {
-        historyManager.getHistory().removeIf(subtasksList::containsValue);
+        List<Task> epicsInHistory = historyManager.getHistory();
+        for (Task task : subtasksList.values()) {
+            if (epicsInHistory.contains(task)) {
+                historyManager.remove(task.getId());
+            }
+        }
     }
 
     private void deleteTaskByIdFromHistory(int id) {
-        historyManager.getHistory().removeIf(task -> (task.getId() == id));
+        historyManager.remove(id);
     }
 
     private void deleteEpicByIdFromHistory(int id) {
@@ -183,23 +202,12 @@ public class InMemoryTaskManager implements TaskManager {
         }
         for (Task subtask : subtaskOfEpicToDelete) {
             subtasksList.remove(subtask.getId());
+            historyManager.remove(subtask.getId());
         }
-        historyManager.getHistory().removeIf(subtaskOfEpicToDelete::contains);
-        historyManager.getHistory().removeIf(task -> (task.getId() == id));
+        historyManager.remove(id);
     }
 
-    private void deleteSubtaskByIdFromHistory(int id, Epic epic) {
-        historyManager.getHistory().removeIf(task -> (task.getId() == id));
-        ArrayList<Integer> indexOfEpicToUpdate = new ArrayList<>();
-        for (int i = 0; i < historyManager.getHistory().size(); i++) {
-            Task task = historyManager.getHistory().get(i);
-            if (task.getId() == epic.getId()) {
-                indexOfEpicToUpdate.add(i);
-            }
-        }
-        for (Integer index : indexOfEpicToUpdate) {
-            historyManager.getHistory().remove((int) index);
-            historyManager.getHistory().add((int) index, epic);
-        }
+    private void deleteSubtaskByIdFromHistory(int id) {
+        historyManager.remove(id);
     }
 }

--- a/src/manager/Managers.java
+++ b/src/manager/Managers.java
@@ -1,10 +1,11 @@
 package manager;
 
 public class Managers {
-    public static TaskManager getDefault(){
+    public static TaskManager getDefault() {
         return new InMemoryTaskManager();
-    };
-    public static HistoryManager getDefaultHistory(){
+    }
+
+    public static HistoryManager getDefaultHistory() {
         return new InMemoryHistoryManager();
-    };
+    }
 }

--- a/src/manager/TaskManager.java
+++ b/src/manager/TaskManager.java
@@ -5,6 +5,7 @@ import classes.tasks.Subtask;
 import classes.tasks.Task;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public interface TaskManager {
     void createTask(Task task);
@@ -44,5 +45,6 @@ public interface TaskManager {
     void deleteSubtaskById(int id);
 
     ArrayList<Subtask> getListOfSubtasksOfEpic(Epic epic);
-    ArrayList<Task> getHistory();
+
+    List<Task> getHistory();
 }

--- a/test/manager/InMemoryHistoryManagerTest.java
+++ b/test/manager/InMemoryHistoryManagerTest.java
@@ -11,12 +11,45 @@ import static org.junit.jupiter.api.Assertions.*;
 class InMemoryHistoryManagerTest {
     @Test
     void add() {
-        HistoryManager historyManager = Managers.getDefaultHistory();
+        TaskManager taskManager = Managers.getDefault();
         Task task = new Task("Test ", "Test  description");
-        historyManager.add(task);
-        final List<Task> history = historyManager.getHistory();
-        assertNotNull(history, "История не пустая.");
-        assertEquals(1, history.size(), "История не пустая.");
+        Task task1 = new Task("Test1 ", "Test  description");
+        Task task2 = new Task("Test2 ", "Test  description");
+        Task task3 = new Task("Test3 ", "Test  description");
+        Task task4 = new Task("Test4 ", "Test  description");
+        Task task5 = new Task("Test5 ", "Test  description");
+        Task task6 = new Task("Test6 ", "Test  description");
+        Task task7 = new Task("Test7 ", "Test  description");
+        Task task8 = new Task("Test8 ", "Test  description");
+        taskManager.createTask(task);
+        taskManager.createTask(task2);
+        taskManager.createTask(task3);
+        taskManager.createTask(task4);
+        taskManager.createTask(task5);
+        taskManager.createTask(task6);
+        taskManager.createTask(task7);
+        taskManager.createTask(task8);
+        taskManager.getTaskById(1);
+        taskManager.getTaskById(1);
+        taskManager.getTaskById(2);
+        taskManager.getTaskById(3);
+        taskManager.getTaskById(4);
+        taskManager.getTaskById(4);
+        taskManager.getTaskById(5);
+        taskManager.getTaskById(6);
+        taskManager.getTaskById(2);
+        taskManager.getTaskById(1);
+        taskManager.getTaskById(2);
+        taskManager.getTaskById(3);
+        taskManager.getTaskById(2);
+        taskManager.getTaskById(3);
+
+        final List<Task> history = taskManager.getHistory();
+        for (Task tasks : history) {
+            System.out.println(tasks);
+        }
+        assertNotNull(history, "История  пустая.");
+        assertEquals(6, history.size(), "История  пустая.");
     }
 
     @Test
@@ -26,13 +59,16 @@ class InMemoryHistoryManagerTest {
             Task task = new Task("Test " + i, "Test  description");
             taskManager.createTask(task);
         }
-        for (int i = 1; i < 20; i++) {
+        for (int i = 1; i <= 20; i++) {
             taskManager.getTaskById(i);
         }
         final List<Task> history = taskManager.getHistory();
+        for (Task task : history) {
+            System.out.println(task);
+        }
         assertNotNull(history, "История не пустая.");
-        assertEquals(10, history.size(), "История не пустая.");
-        assertEquals(19, history.getLast().getId(), "Не та таска  в конце истории");
-        assertEquals(10, history.getFirst().getId(), "Не та таска  в начале истории");
+        assertEquals(20, history.size(), "История не пустая.");
+        assertEquals(20, history.getLast().getId(), "Не та таска  в конце истории");
+        assertEquals(1, history.getFirst().getId(), "Не та таска  в начале истории");
     }
 }

--- a/test/manager/InMemoryHistoryManagerTest.java
+++ b/test/manager/InMemoryHistoryManagerTest.java
@@ -1,6 +1,5 @@
 package manager;
 
-import classes.tasks.Epic;
 import classes.tasks.Task;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +12,6 @@ class InMemoryHistoryManagerTest {
     void add() {
         TaskManager taskManager = Managers.getDefault();
         Task task = new Task("Test ", "Test  description");
-        Task task1 = new Task("Test1 ", "Test  description");
         Task task2 = new Task("Test2 ", "Test  description");
         Task task3 = new Task("Test3 ", "Test  description");
         Task task4 = new Task("Test4 ", "Test  description");

--- a/test/manager/InMemoryTaskManagerTest.java
+++ b/test/manager/InMemoryTaskManagerTest.java
@@ -101,10 +101,11 @@ class InMemoryTaskManagerTest {
 
         final List<Task> history = taskManager.getHistory();
         assertNotNull(history, "История не пустая.");
-        assertEquals(10, history.size(), "История не пустая.");
+        assertEquals(6, history.size(), "История не пустая.");
         taskManager.deleteTasks();
+        final List<Task> history1 = taskManager.getHistory();
         assertEquals(new ArrayList<>(), taskManager.getListOfTasks(), "Задачи не удалились");
-        assertEquals(4, history.size(), "Неправильно удалилось");
+        assertEquals(3, history1.size(), "Неправильно удалилось");
     }
 
     @Test
@@ -138,8 +139,9 @@ class InMemoryTaskManagerTest {
         taskManager.getSubtaskById(43);
         final List<Task> history = taskManager.getHistory();
         taskManager.deleteEpics();
+        final List<Task> history1 = taskManager.getHistory();
         assertEquals(new ArrayList<>(), taskManager.getListOfEpics(), "Задачи не удалились");
-        assertEquals(3, history.size(), "Неправильно удалилась");
+        assertEquals(3, history1.size(), "Неправильно удалилась");
     }
 
     @Test
@@ -156,12 +158,23 @@ class InMemoryTaskManagerTest {
             Subtask subtask = new Subtask("Test " + i, "Test  description", 2);
             taskManager.createSubtask(subtask);
         }
+        taskManager.getSubtaskById(3);
+        taskManager.getSubtaskById(4);
+        taskManager.getSubtaskById(5);
+        taskManager.getSubtaskById(3);
+        taskManager.getSubtaskById(4);
+        taskManager.getSubtaskById(5);
+        taskManager.getSubtaskById(3);
+        taskManager.getSubtaskById(4);
+        taskManager.getEpicById(1);
+        taskManager.getEpicById(2);
+        taskManager.getSubtaskById(5);
         taskManager.deleteSubtasks();
         assertEquals(new ArrayList<>(), taskManager.getListOfSubtasks(), "Задачи не удалились");
         assertEquals(new ArrayList<>(), taskManager.getListOfSubtasksOfEpic(epic), "Задачи не удалились в эпике");
         assertEquals(new ArrayList<>(), taskManager.getListOfSubtasksOfEpic(epic1), "Задачи не удалились в эпике 1");
         assertEquals(Status.NEW, taskManager.getEpicById(1).getStatus(), "Статус не изменился");
-        assertEquals(Status.NEW, taskManager.getEpicById(2).getStatus(), "Статус не изменился");
+        assertEquals(Status.NEW, taskManager.getEpicById(1).getStatus(), "Статус не изменился");
     }
 
 
@@ -273,9 +286,9 @@ class InMemoryTaskManagerTest {
         taskManager.getSubtaskById(41);
         taskManager.getSubtaskById(42);
         taskManager.getSubtaskById(43);
-        final List<Task> history = taskManager.getHistory();
         assertEquals(5, taskManager.getListOfSubtasks().size(), "Неправильно добавились подзадачи");
         taskManager.deleteEpicById(21);
+        final List<Task> history = taskManager.getHistory();
         assertEquals(3, taskManager.getListOfSubtasks().size(), "Неправильно удалились подзадачи");
         assertEquals(19, taskManager.getListOfEpics().size(), "Неправильно удалился эпик");
         assertEquals(6, history.size(), "Неправильно удалилась");

--- a/test/manager/InMemoryTaskManagerTest.java
+++ b/test/manager/InMemoryTaskManagerTest.java
@@ -35,7 +35,7 @@ class InMemoryTaskManagerTest {
 
         assertNotNull(tasks, "Задачи не возвращаются.");
         assertEquals(1, tasks.size(), "Неверное количество задач.");
-        assertEquals(task, tasks.get(0), "Задачи не совпадают.");
+        assertEquals(task, tasks.getFirst(), "Задачи не совпадают.");
     }
 
     @Test
@@ -53,7 +53,7 @@ class InMemoryTaskManagerTest {
 
         assertNotNull(epics, "Задачи не возвращаются.");
         assertEquals(1, epics.size(), "Неверное количество задач.");
-        assertEquals(epic, epics.get(0), "Задачи не совпадают.");
+        assertEquals(epic, epics.getFirst(), "Задачи не совпадают.");
     }
 
     @Test
@@ -73,7 +73,7 @@ class InMemoryTaskManagerTest {
 
         assertNotNull(subtasks, "Задачи не возвращаются.");
         assertEquals(1, subtasks.size(), "Неверное количество задач.");
-        assertEquals(subtask, subtasks.get(0), "Задачи не совпадают.");
+        assertEquals(subtask, subtasks.getFirst(), "Задачи не совпадают.");
     }
 
 
@@ -137,7 +137,6 @@ class InMemoryTaskManagerTest {
         taskManager.getSubtaskById(41);
         taskManager.getSubtaskById(42);
         taskManager.getSubtaskById(43);
-        final List<Task> history = taskManager.getHistory();
         taskManager.deleteEpics();
         final List<Task> history1 = taskManager.getHistory();
         assertEquals(new ArrayList<>(), taskManager.getListOfEpics(), "Задачи не удалились");
@@ -184,7 +183,7 @@ class InMemoryTaskManagerTest {
         taskManager.createTask(task);
         task.setStatus(Status.IN_PROGRESS);
         taskManager.updateTask(task);
-        assertEquals(Status.IN_PROGRESS, taskManager.getTaskById(1).getStatus(), "Задача не обновалась");
+        assertEquals(Status.IN_PROGRESS, taskManager.getTaskById(1).getStatus(), "Задача не обновилась");
         assertEquals(1, taskManager.getListOfTasks().size(), "Задача добавилась как новая");
     }
 
@@ -194,7 +193,7 @@ class InMemoryTaskManagerTest {
         taskManager.createEpic(epic);
         epic.setStatus(Status.IN_PROGRESS);
         taskManager.updateEpic(epic);
-        assertEquals(Status.IN_PROGRESS, taskManager.getEpicById(1).getStatus(), "Задача не обновалась");
+        assertEquals(Status.IN_PROGRESS, taskManager.getEpicById(1).getStatus(), "Задача не обновилась");
         assertEquals(1, taskManager.getListOfEpics().size(), "Задача добавилась как новая");
     }
 


### PR DESCRIPTION
С помощью своего варианта связного списка, который очень схож с LinkedHashMap, организовал историю просмотров,  в которой нет повторений, все задачи находятся в порядке их добавления, а также удаление происходит за О(1). Также поправил тесты, чтобы они подходили под новый тип истории